### PR TITLE
Dockerfile: Add libpq5 as needed for starting it on armhf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && apt-get install -y curl && \
     curl -sL https://deb.nodesource.com/setup_17.x | bash -
 
 RUN apt-get update && apt-get install -y \
+    libpq5 \
     nodejs \
     node-typescript \
     jq \


### PR DESCRIPTION
When trying to build and start it on an armhf machine, libpq.so.5 was missing in the container. Ensure it's installed.

BTW: On adding the trailing newlines. Editors like vim are configured to add a trailing newline by default.
It's more compatible with contributions to just have a trailing newline in files, which is the standard all larger open-source projects.